### PR TITLE
Enforce audience claim - fixes #4

### DIFF
--- a/cmd/scitoken-validate/main.go
+++ b/cmd/scitoken-validate/main.go
@@ -18,6 +18,8 @@ var (
 		"scope to validate, with optional path delimited by colon. Can be repeated.")
 	groups *[]string = flag.StringSliceP("group", "g", []string{},
 		"WLCG group to validate. The leading slash on the group name is optional. Can be repeated.")
+	audiences *string = flag.StringSliceP("audience", "a", []string{},
+		"audience to validate (or any). Can be repeated.")
 	verbose *bool = flag.BoolP("verbose", "v", false,
 		"extra logging of token information and internals to stderr.")
 )
@@ -38,6 +40,9 @@ scope paths will validate sub-paths (see example).
 
 Optionally pass one or more WLCG groups to require with the --group/-g flag. Note
 that groups WILL NOT validate sub-groups (see example).
+
+Optionally pass one or more audiences to require with the --audience/-a flag.
+This will also validate if the token has one of the special "any" audiences.
 
 If the token is not valid an explanation message will be printed to stderr and
 the program will terminate with exit code 1.

--- a/cmd/scitoken-validate/main.go
+++ b/cmd/scitoken-validate/main.go
@@ -18,7 +18,7 @@ var (
 		"scope to validate, with optional path delimited by colon. Can be repeated.")
 	groups *[]string = flag.StringSliceP("group", "g", []string{},
 		"WLCG group to validate. The leading slash on the group name is optional. Can be repeated.")
-	audiences *string = flag.StringSliceP("audience", "a", []string{},
+	audiences *[]string = flag.StringSliceP("audience", "a", []string{},
 		"audience to validate (or any). Can be repeated.")
 	verbose *bool = flag.BoolP("verbose", "v", false,
 		"extra logging of token information and internals to stderr.")
@@ -84,6 +84,9 @@ func main() {
 	// Validation constraints can be added to the base Enforcer...
 	for _, s := range *scopes {
 		enf.RequireScope(scitoken.ParseScope(s))
+	}
+	for _, a := range *audiences {
+		enf.RequireAudience(a)
 	}
 
 	// ... or added on at parse time.

--- a/enforcer.go
+++ b/enforcer.go
@@ -51,6 +51,11 @@ func (e *Enforcer) AddIssuer(ctx context.Context, issuer string) error {
 	return nil
 }
 
+// RequireAudience adds aud to audiences to validate.
+func (e *Enforcer) RequireAudience(aud string) error {
+	return e.RequireValidator(WithAudience(aud))
+}
+
 // RequireScope adds s to scopes to validate.
 func (e *Enforcer) RequireScope(s Scope) error {
 	return e.RequireValidator(WithScope(s))
@@ -224,9 +229,15 @@ func tokenFilename() string {
 
 // Validate checks that the SciToken is valid and meets all constraints imposed
 // by the Enforcer, namely:
+//
 // * the issuer is accepted (via AddIssuer) and the token was signed by it
-// * all scopes added by RequiredScope are present in the scope claim
-// * all groups added by RequiredGroup are present in the wlcg.groups claim
+//
+// * all audiences added by RequireAudience or one of the recognized "any"
+//   audiences are present in the aud claim.
+//
+// * all scopes added by RequireScope are present in the scope claim
+//
+// * all groups added by RequireGroup are present in the wlcg.groups claim
 //
 // This can be called multiple times, e.g. to test the token against different
 // scopes.

--- a/errors.go
+++ b/errors.go
@@ -13,6 +13,7 @@ var (
 	TokenNotFoundError     = errors.New("token not found")
 	ScopeParseError        = errors.New("unable to unmarshal and parse scope claim")
 	GroupParseError        = errors.New("unable to unmarshal wlcg.groups claim")
+	VersionParseError      = errors.New("unable to unmarshal ver claim")
 )
 
 type TokenValidationError struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,16 @@
+package scitokens
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidationError(t *testing.T) {
+	assert := assert.New(t)
+	err1 := errors.New("oops")
+	err2 := &TokenValidationError{err1}
+	assert.Equal("token invalid: oops", err2.Error())
+	assert.ErrorIs(err2, err1)
+}

--- a/key_test.go
+++ b/key_test.go
@@ -107,7 +107,7 @@ func (s *fakeAuthServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // MakeToken creates and signs a test token with the given scopes and groups.
-func (s *fakeAuthServer) MakeToken(issuer string, scopes, groups interface{}) ([]byte, error) {
+func (s *fakeAuthServer) MakeToken(issuer string, scopes, groups, audience interface{}) ([]byte, error) {
 	t := jwt.New()
 	t.Set("iss", issuer)
 	t.Set("iat", time.Now())
@@ -120,6 +120,11 @@ func (s *fakeAuthServer) MakeToken(issuer string, scopes, groups interface{}) ([
 	}
 	if groups != nil {
 		if err := t.Set("wlcg.groups", groups); err != nil {
+			return nil, err
+		}
+	}
+	if audience != nil {
+		if err := t.Set("aud", audience); err != nil {
 			return nil, err
 		}
 	}

--- a/scitoken.go
+++ b/scitoken.go
@@ -13,74 +13,98 @@ type SciToken interface {
 	jwt.Token
 	Scopes() []Scope
 	Groups() []string
+	Version() string
 }
 
 type sciToken struct {
-	token  jwt.Token
-	scopes []Scope
-	groups []string
+	token   jwt.Token
+	scopes  []Scope
+	groups  []string
+	version string
 }
 
 // NewSciToken wraps a jwt.Token, populating the SciToken from the custom
 // claims.
 func NewSciToken(t jwt.Token) (SciToken, error) {
-	st := sciToken{
+	st := &sciToken{
 		token: t,
 	}
-	var err error
-	st.scopes, err = GetScopes(t)
-	if err != nil {
-		return st, err
-	}
-	st.groups, err = GetGroups(t)
-	return st, err
+	return st, st.update()
 }
 
-func (t sciToken) Audience() []string {
+func (t *sciToken) update() error {
+	var err error
+	t.scopes, err = GetScopes(t)
+	if err != nil {
+		return err
+	}
+
+	t.groups, err = GetGroups(t)
+	if err != nil {
+		return err
+	}
+
+	t.version, err = GetVersion(t)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *sciToken) Audience() []string {
 	return t.token.Audience()
 }
 
-func (t sciToken) Expiration() time.Time {
+func (t *sciToken) Expiration() time.Time {
 	return t.token.Expiration()
 }
 
-func (t sciToken) IssuedAt() time.Time {
+func (t *sciToken) IssuedAt() time.Time {
 	return t.token.IssuedAt()
 }
 
-func (t sciToken) Issuer() string {
+func (t *sciToken) Issuer() string {
 	return t.token.Issuer()
 }
 
-func (t sciToken) JwtID() string {
+func (t *sciToken) JwtID() string {
 	return t.token.JwtID()
 }
 
-func (t sciToken) NotBefore() time.Time {
+func (t *sciToken) NotBefore() time.Time {
 	return t.token.NotBefore()
 }
 
-func (t sciToken) Subject() string {
+func (t *sciToken) Subject() string {
 	return t.token.Subject()
 }
 
-func (t sciToken) PrivateClaims() map[string]interface{} {
+func (t *sciToken) PrivateClaims() map[string]interface{} {
 	return t.token.PrivateClaims()
 }
 
-func (t sciToken) Get(name string) (interface{}, bool) {
+func (t *sciToken) Get(name string) (interface{}, bool) {
 	return t.token.Get(name)
 }
 
-func (t sciToken) Set(name string, value interface{}) error {
-	return t.token.Set(name, value)
+func (t *sciToken) Set(name string, value interface{}) error {
+	err := t.token.Set(name, value)
+	if err != nil {
+		return err
+	}
+	return t.update()
 }
 
-func (t sciToken) Remove(name string) error {
-	return t.token.Remove(name)
+func (t *sciToken) Remove(name string) error {
+	err := t.token.Remove(name)
+	if err != nil {
+		return err
+	}
+	return t.update()
 }
 
-func (t sciToken) Clone() (jwt.Token, error) {
+func (t *sciToken) Clone() (jwt.Token, error) {
 	nt, err := t.token.Clone()
 	if err != nil {
 		return nt, err
@@ -88,22 +112,26 @@ func (t sciToken) Clone() (jwt.Token, error) {
 	return NewSciToken(nt)
 }
 
-func (t sciToken) Iterate(ctx context.Context) jwt.Iterator {
+func (t *sciToken) Iterate(ctx context.Context) jwt.Iterator {
 	return t.token.Iterate(ctx)
 }
 
-func (t sciToken) Walk(ctx context.Context, v jwt.Visitor) error {
+func (t *sciToken) Walk(ctx context.Context, v jwt.Visitor) error {
 	return t.token.Walk(ctx, v)
 }
 
-func (t sciToken) AsMap(ctx context.Context) (map[string]interface{}, error) {
+func (t *sciToken) AsMap(ctx context.Context) (map[string]interface{}, error) {
 	return t.token.AsMap(ctx)
 }
 
-func (t sciToken) Scopes() []Scope {
+func (t *sciToken) Scopes() []Scope {
 	return t.scopes
 }
 
-func (t sciToken) Groups() []string {
+func (t *sciToken) Groups() []string {
 	return t.groups
+}
+
+func (t *sciToken) Version() string {
+	return t.version
 }

--- a/scitoken_test.go
+++ b/scitoken_test.go
@@ -130,6 +130,24 @@ func TestNewSciToken(t *testing.T) {
 		_, err := NewSciToken(t1)
 		assert.Error(err, "NewSciToken should fail")
 	})
+	t.Run("SciToken with invalid audience", func(t *testing.T) {
+		assert := assert.New(t)
+		t1 := jwt.New()
+		st1, err := NewSciToken(t1)
+		if !assert.NoError(err, "NewSciToken should succeed") {
+			return
+		}
+		assert.Error(st1.Set("aud", 0), "setting aud should fail")
+	})
+	t.Run("SciToken with invalid version", func(t *testing.T) {
+		assert := assert.New(t)
+		t1 := jwt.New()
+		if !assert.NoError(t1.Set("ver", 0), "setting ver should succeed") {
+			return
+		}
+		_, err := NewSciToken(t1)
+		assert.Error(err, "NewSciToken should fail")
+	})
 	t.Run("Parsed SciTokens", func(t *testing.T) {
 		assert := assert.New(t)
 		for _, tok := range testTokens {

--- a/scitoken_test.go
+++ b/scitoken_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// a token where everything that can go wrong, does
+// a jwt.Token where everything that can go wrong, does
 type murphyToken struct{}
 
 var murphyError = errors.New("Murphy says no")

--- a/scitoken_test.go
+++ b/scitoken_test.go
@@ -9,18 +9,33 @@ import (
 )
 
 type testToken struct {
-	Name    string
-	Data    []byte
-	Subject string
-	Issuer  string
-	Scopes  []Scope
-	Groups  []string
+	Name     string
+	Data     []byte
+	Subject  string
+	Issuer   string
+	Scopes   []Scope
+	Groups   []string
+	Version  string
+	Audience []string
 }
 
 var (
 	// It goes without saying, but I'll say it anyways:
 	// EXPIRED TOKENS ONLY
 	testTokens = []testToken{
+		{
+			Name:    "bare SciToken",
+			Data:    []byte("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiYm9ja2VsbSIsImV4cCI6MTUwOTk5MTc5MCwiaXNzIjoiaHR0cHM6Ly9zY2l0b2tlbnMub3JnL2NtcyIsImlhdCI6MTUwOTk4ODE5MCwic2NvcGUiOiJyZWFkOi9zdG9yZSB3cml0ZTovc3RvcmUvdXNlci9iYm9ja2VsbSIsIm5iZiI6MTUwOTk4ODE5MCwidmVyIjoic2NpdG9rZW46Mi4wIiwiYXVkIjoiaHR0cHM6Ly9jbXMuZXhhbXBsZS5jb20ifQ.fCtyZQQNPaowQ5FXFVIlbt2Qpb4ui8Bkl1qXpwLKI3FQ0AKP64Ozf7NLKI8nRHaAqh9XRQAxB9YtAJAeHriSN422-CraARoYyBdrZMtwlxphOLPkpuxbIusVYB3r4zIRt4BoB7NlqLqwVV2e5rGtkJGvi9tpY2FNr7eZ6eBrzAg"),
+			Subject: "bbockelm",
+			Issuer:  "https://scitokens.org/cms",
+			Scopes: []Scope{
+				{"read", "/store"},
+				{"write", "/store/user/bbockelm"},
+			},
+			Groups:   []string{},
+			Version:  "scitoken:2.0",
+			Audience: []string{"https://transfer-server.example.com"},
+		},
 		{
 			Name:    "WLCG test issuer",
 			Data:    []byte(`eyJraWQiOiJyc2ExIiwiYWxnIjoiUlMyNTYifQ.eyJ3bGNnLnZlciI6IjEuMCIsInN1YiI6ImM3NWMzMmNiLTU0ZGUtNDY2MC04NjVjLTFkNWM4NjlkMGQ3YSIsImF1ZCI6Imh0dHBzOlwvXC93bGNnLmNlcm4uY2hcL2p3dFwvdjFcL2FueSIsIm5iZiI6MTYzMzEyMTE1OCwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSBvZmZsaW5lX2FjY2VzcyBlbWFpbCB3bGNnIHdsY2cuZ3JvdXBzIiwiaXNzIjoiaHR0cHM6XC9cL3dsY2cuY2xvdWQuY25hZi5pbmZuLml0XC8iLCJleHAiOjE2MzMxMjQ3NTgsImlhdCI6MTYzMzEyMTE1OCwianRpIjoiOWU4OGFmNzAtZGIxMi00NWRlLWEwZTMtZDc3YTA0OTNhNzM0IiwiY2xpZW50X2lkIjoiY2Q1NjIzZTMtMTZkYS00MTU2LWEzNWYtYzBiOWU0MTkwZTA0Iiwid2xjZy5ncm91cHMiOlsiXC93bGNnIl19.dlz0VLighqFIyQ6wRk8kehRACfVnqSxRfZrAAaqneFgNCfhbGY65ZaAgCPHl2avfqRumYOqHr9PTbQLFp9bx6CV_Oa7kWguGOo2Dm59aoGO_XrlvhtGYJ3uxYUN6jQ8ZyQYaR8fgJmC3m1S_sVu56yg0HMC1jfFhCWec-cyes80`),
@@ -34,7 +49,9 @@ var (
 				{"wlcg", ""},
 				{"wlcg.groups", ""},
 			},
-			Groups: []string{"/wlcg"},
+			Groups:   []string{"/wlcg"},
+			Version:  "wlcg:1.0",
+			Audience: []string{"https://wlcg.cern.ch/jwt/v1/any"},
 		},
 	}
 )
@@ -141,6 +158,8 @@ func TestNewSciToken(t *testing.T) {
 				assert.Equal(st.Issuer(), tok.Issuer)
 				assert.Equal(st.Scopes(), tok.Scopes)
 				assert.Equal(st.Groups(), tok.Groups)
+				assert.Equal(st.Version(), tok.Version)
+				assert.Equal(st.Audience(), tok.Audience)
 			})
 		}
 	})

--- a/util_test.go
+++ b/util_test.go
@@ -108,3 +108,39 @@ func TestGetGroups(t *testing.T) {
 		assert.Error(err, "GetGroups should fail")
 	})
 }
+
+func TestGetVersion(t *testing.T) {
+	assert := assert.New(t)
+	t1 := jwt.New()
+	t.Run("no version", func(t *testing.T) {
+		v, err := GetVersion(t1)
+		if !assert.NoError(err, "GetVersion should succeed") {
+			return
+		}
+		assert.Equal(v, "")
+	})
+	t.Run("bad version", func(t *testing.T) {
+		assert.NoError(t1.Set("ver", 0))
+		_, err := GetVersion(t1)
+		if !assert.Error(err, "GetVersion should fail") {
+			return
+		}
+	})
+	t.Run("scitoken", func(t *testing.T) {
+		assert.NoError(t1.Set("ver", "scitoken:1.0"))
+		v, err := GetVersion(t1)
+		if !assert.NoError(err, "GetVersion should succeed") {
+			return
+		}
+		assert.Equal(v, "scitoken:1.0")
+	})
+	t.Run("WLCG token", func(t *testing.T) {
+		assert.NoError(t1.Remove("ver"))
+		assert.NoError(t1.Set("wlcg.ver", "1.0"))
+		v, err := GetVersion(t1)
+		if !assert.NoError(err, "GetVersion should succeed") {
+			return
+		}
+		assert.Equal(v, "wlcg:1.0")
+	})
+}

--- a/util_test.go
+++ b/util_test.go
@@ -17,7 +17,6 @@ func TestPrintToken(t *testing.T) {
 	t1.Set("sub", "my-subject")
 	t1.Set("iss", "my-issuer")
 	t1.Set("aud", []string{"my-audience"})
-	t1.Set("foo", "bar")
 	PrintToken(&buf, t1)
 	ref := `Token version: scitoken:1.0, ID: my-id
 Subject: my-subject
@@ -26,7 +25,6 @@ Audience: [my-audience]
 Issued at: 0001-01-01 00:00:00 +0000 UTC, Valid after: 0001-01-01 00:00:00 +0000 UTC, Expires at: 0001-01-01 00:00:00 +0000 UTC
 Claims:
 	ver: scitoken:1.0
-	foo: bar
 `
 	assert.Equal(ref, buf.String())
 }

--- a/util_test.go
+++ b/util_test.go
@@ -12,19 +12,23 @@ func TestPrintToken(t *testing.T) {
 	assert := assert.New(t)
 	var buf bytes.Buffer
 	t1 := jwt.New()
+	t1.Set("ver", "scitoken:1.0")
+	t1.Set("jti", "my-id")
 	t1.Set("sub", "my-subject")
 	t1.Set("iss", "my-issuer")
 	t1.Set("aud", []string{"my-audience"})
 	t1.Set("foo", "bar")
 	PrintToken(&buf, t1)
-	ref := `Subject: my-subject
+	ref := `Token version: scitoken:1.0, ID: my-id
+Subject: my-subject
 Issuer: my-issuer
 Audience: [my-audience]
-Issued at: 0001-01-01 00:00:00 +0000 UTC, Expires at: 0001-01-01 00:00:00 +0000 UTC
+Issued at: 0001-01-01 00:00:00 +0000 UTC, Valid after: 0001-01-01 00:00:00 +0000 UTC, Expires at: 0001-01-01 00:00:00 +0000 UTC
 Claims:
+	ver: scitoken:1.0
 	foo: bar
 `
-	assert.Equal(buf.String(), ref)
+	assert.Equal(ref, buf.String())
 }
 
 func TestGetScopes(t *testing.T) {

--- a/validator.go
+++ b/validator.go
@@ -81,13 +81,14 @@ func WithAudience(audience string) Validator {
 }
 
 func (v audienceValidator) Validate(ctx context.Context, t jwt.Token) error {
-	ver, err := GetVersion(t)
-	if err != nil {
-		return err
+	st, ok := t.(SciToken)
+	if !ok {
+		return NotSciTokenError
 	}
 
-	auds := t.Audience()
+	auds := st.Audience()
 	if len(auds) == 0 {
+		ver := st.Version()
 		// The aud claim is OPTIONAL in scitoken version 1.0, mandatory in 2.0
 		// and WLCG profile tokens.
 		if ver == "" || ver == "scitoken:1.0" {

--- a/validator.go
+++ b/validator.go
@@ -59,3 +59,55 @@ func (v groupValidator) Validate(ctx context.Context, t jwt.Token) error {
 	}
 	return fmt.Errorf("missing the following group: %s", v.group)
 }
+
+// AnyAudiences is the list of special wildcard audiences that a token can
+// present to be used anywhere that otherwise accepts it.
+//
+// * ANY ([SciTokens](https://scitokens.org/technical_docs/Claims.html))
+// * https://wlcg.cern.ch/jwt/v1/any ([WLCG](https://zenodo.org/record/3460258))
+var AnyAudiences = []string{
+	"ANY",
+	"https://wlcg.cern.ch/jwt/v1/any",
+}
+
+type audienceValidator struct {
+	audience string
+}
+
+// WithAudience validates that the token has the given audience or one of the
+// supported "any" audiences.
+func WithAudience(audience string) Validator {
+	return audienceValidator{audience}
+}
+
+func (v audienceValidator) Validate(ctx context.Context, t jwt.Token) error {
+	ver, err := GetVersion(t)
+	if err != nil {
+		return err
+	}
+
+	auds := t.Audience()
+	if len(auds) == 0 {
+		// The aud claim is OPTIONAL in scitoken version 1.0, mandatory in 2.0
+		// and WLCG profile tokens.
+		if ver == "" || ver == "scitoken:1.0" {
+			return nil
+		}
+		return fmt.Errorf("aud claim is mandatory")
+	}
+
+	// are we one of the target audience or does the token have one of the
+	// recognized "any" audiences?
+	for _, aud := range auds {
+		if aud == v.audience {
+			return nil
+		}
+		for _, any := range AnyAudiences {
+			if aud == any {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("expected audience %s or %v, token has %v", v.audience, AnyAudiences, t.Audience())
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -66,3 +66,29 @@ func TestGroupValidator(t *testing.T) {
 	v = WithGroup("foo/bar")
 	assert.Error(v.Validate(ctx, st1), "token does not have sub-group foo/bar")
 }
+
+func TestAudienceValidator(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	t1 := jwt.New()
+	t1.Set("ver", "scitoken:2.0")
+	t1.Set("aud", "foo")
+	st1, err := NewSciToken(t1)
+	if !assert.NoError(err) {
+		return
+	}
+
+	v := WithAudience("foo")
+	assert.ErrorIs(v.Validate(ctx, t1), NotSciTokenError, "cannot validate non-SciToken")
+	assert.NoError(v.Validate(ctx, st1), "token has audience foo")
+
+	v = WithGroup("foo")
+	assert.NoError(v.Validate(ctx, st1), "leading slash is optional")
+
+	v = WithGroup("bar")
+	assert.Error(v.Validate(ctx, st1), "token does not have group bar")
+
+	v = WithGroup("foo/bar")
+	assert.Error(v.Validate(ctx, st1), "token does not have sub-group foo/bar")
+}


### PR DESCRIPTION
This add a `WithAudience` validator and a convenience `RequireAudience` method on Enforcer. If specified, the enforcer will check that the token has the audience string specified, or one of the special wildcard audiences, by default "ANY" and "https://wlcg.cern.ch/jwt/v1/any". If not specified, audience will not be checked at all.